### PR TITLE
Shorten and simplify code

### DIFF
--- a/banditscript.py
+++ b/banditscript.py
@@ -4,13 +4,11 @@ nextpass = ''
 
 for i in range(6):
     data = []
-    myfile = open("bandit"+str(i)+".cfg", "r")
-    while myfile:
-        line  = myfile.readline()
-        data.append(line)
-        if line == "":
-            break
-    myfile.close()
+    with open("bandit"+str(i)+".cfg", "r") as myfile:
+        while myfile:
+            data.append(line := myfile.readline())
+            if line == "":
+                break
 
 
     address = data[0].rstrip("\n").split(": ")[1]
@@ -32,20 +30,18 @@ for i in range(6):
 
     if(len(commands)>1):
         command = '&&'
-        command = command.join(commands)
-        print(command)
+        print(command := command.join(commands))
 
     else:
         command = commands[0]
 
 
-    nextpass = repr(session(command))
-    print(nextpass)
+    print(nextpass := repr(session(command)))
+    
     '''
     for commandind in range(len(commands)):
         if(commandind == len(commands)-1):
-            nextpass = repr(session(commands[commandind]))
-            print(nextpass)
+            print(nextpass := repr(session(commands[commandind])))
         else:
             print(repr(session(commands[commandind])))
 


### PR DESCRIPTION
I made it so when you use 'open', you don't have to close it by using "with open() as" instead. I also added some uses of the walrus operator in order to shorten your code by setting variables inside print statements and other function statements.
Note: If this is not intended for use with python 3.8 or above, please discard this pull request as the walrus operator will not be recognized on earlier versions.